### PR TITLE
Add pre_process / post_process JS hooks

### DIFF
--- a/Sources/ChatClientKit/ChatService.swift
+++ b/Sources/ChatClientKit/ChatService.swift
@@ -5,6 +5,17 @@ public protocol ChatService: AnyObject, Sendable {
 
     func chat(body: ChatRequestBody) async throws -> ChatResponse
     func streamingChat(body: ChatRequestBody) async throws -> AnyAsyncSequence<ChatResponseChunk>
+
+    /// Scripting-aware entry point. Default implementation forwards to
+    /// `streamingChat(body:)` (i.e. scripting disabled). Conformers that
+    /// actually run the JavaScript hooks (`RemoteCompletionsChatClient`,
+    /// `RemoteResponsesChatClient`) override this. Local-inference
+    /// clients (MLX, Apple Intelligence) keep the default since they
+    /// don't issue network requests and `scripting` is not meaningful.
+    func streamingChat(
+        body: ChatRequestBody,
+        scripting: ChatScriptingHandle?
+    ) async throws -> AnyAsyncSequence<ChatResponseChunk>
 }
 
 public extension ChatService {
@@ -23,6 +34,11 @@ public extension ChatService {
         return ChatResponse(chunks: chunks)
     }
 
+    func chat(body: ChatRequestBody, scripting: ChatScriptingHandle?) async throws -> ChatResponse {
+        let chunks: [ChatResponseChunk] = try await chatChunks(body: body, scripting: scripting)
+        return ChatResponse(chunks: chunks)
+    }
+
     func chat(_ request: some ChatRequestConvertible) async throws -> ChatResponse {
         try await chat(body: request.asChatRequestBody())
     }
@@ -30,8 +46,15 @@ public extension ChatService {
     // MARK: CHAT RESPONSE CHUNKS
 
     func chatChunks(body: ChatRequestBody) async throws -> [ChatResponseChunk] {
+        try await chatChunks(body: body, scripting: nil)
+    }
+
+    func chatChunks(
+        body: ChatRequestBody,
+        scripting: ChatScriptingHandle?
+    ) async throws -> [ChatResponseChunk] {
         var chunks: [ChatResponseChunk] = []
-        for try await chunk in try await streamingChat(body: body) {
+        for try await chunk in try await streamingChat(body: body, scripting: scripting) {
             chunks.append(chunk)
         }
         return chunks
@@ -48,6 +71,16 @@ public extension ChatService {
     }
 
     // MARK: STREAMING CHAT RESPONSE CHUNKS
+
+    /// Default implementation: forward to the no-scripting variant.
+    /// Override in clients that support scripting (RemoteCompletions /
+    /// RemoteResponses).
+    func streamingChat(
+        body: ChatRequestBody,
+        scripting _: ChatScriptingHandle?
+    ) async throws -> AnyAsyncSequence<ChatResponseChunk> {
+        try await streamingChat(body: body)
+    }
 
     func streamingChat(
         @ChatRequestBuilder _ builder: @Sendable () -> [ChatRequest.BuildComponent]

--- a/Sources/ChatClientKit/RemoteCompletionsChatClient/RemoteCompletionsChatClient.swift
+++ b/Sources/ChatClientKit/RemoteCompletionsChatClient/RemoteCompletionsChatClient.swift
@@ -72,8 +72,25 @@ public final class RemoteCompletionsChatClient: ChatService {
     public func streamingChat(
         body: ChatRequestBody
     ) async throws -> AnyAsyncSequence<ChatResponseChunk> {
+        try await streamingChat(body: body, scripting: nil)
+    }
+
+    public func streamingChat(
+        body: ChatRequestBody,
+        scripting: ChatScriptingHandle?
+    ) async throws -> AnyAsyncSequence<ChatResponseChunk> {
         let requestBody = resolve(body: body, stream: true)
-        let request = try makeURLRequest(body: requestBody)
+
+        // Build the per-request scripting runtime (if configured).
+        // The runner stays alive for the duration of this streamingChat
+        // call — one runner per request, never reused across requests.
+        let runtime = try makeScriptRuntime(body: requestBody, scripting: scripting)
+
+        let request = try makeURLRequest(
+            body: requestBody,
+            preProcessor: runtime?.preProcessor
+        )
+
         let this = self
         logger.info("starting streaming request to model: \(this.model) with \(body.messages.count) messages, temperature: \(body.temperature ?? 1.0)")
 
@@ -81,7 +98,8 @@ public final class RemoteCompletionsChatClient: ChatService {
             eventSourceFactory: eventSourceFactory,
             chunkDecoder: chunkDecoderFactory(),
             errorExtractor: errorExtractor,
-            reasoningParser: reasoningParser
+            reasoningParser: reasoningParser,
+            postProcessor: runtime?.postProcessor
         )
 
         return processor.stream(request: request) { [weak self] error in
@@ -101,6 +119,31 @@ public final class RemoteCompletionsChatClient: ChatService {
     func makeURLRequest(body: ChatRequestBody) throws -> URLRequest {
         let builder = makeRequestBuilder()
         return try builder.makeRequest(body: body, additionalField: additionalBodyField)
+    }
+
+    func makeURLRequest(
+        body: ChatRequestBody,
+        preProcessor: PreProcessor?
+    ) throws -> URLRequest {
+        let builder = makeRequestBuilder()
+        return try builder.makeRequest(
+            body: body,
+            additionalField: additionalBodyField,
+            preProcessor: preProcessor
+        )
+    }
+
+    /// Build a fresh ScriptRunner + pre/post processors for this request.
+    /// Returns nil if scripting is not enabled.
+    private func makeScriptRuntime(
+        body: ChatRequestBody,
+        scripting: ChatScriptingHandle?
+    ) throws -> ScriptRuntime? {
+        guard let scripting, scripting.config.hasAnyStage else { return nil }
+        return try ScriptRuntime.make(
+            body: body,
+            handle: scripting
+        )
     }
 
     func resolve(body: ChatRequestBody, stream: Bool) -> ChatRequestBody {

--- a/Sources/ChatClientKit/RemoteCompletionsChatClient/RemoteCompletionsChatRequestBuilder.swift
+++ b/Sources/ChatClientKit/RemoteCompletionsChatClient/RemoteCompletionsChatRequestBuilder.swift
@@ -33,6 +33,14 @@ struct RemoteCompletionsChatRequestBuilder {
         body: ChatRequestBody,
         additionalField: [String: Any]
     ) throws -> URLRequest {
+        try makeRequest(body: body, additionalField: additionalField, preProcessor: nil)
+    }
+
+    func makeRequest(
+        body: ChatRequestBody,
+        additionalField: [String: Any],
+        preProcessor: PreProcessor?
+    ) throws -> URLRequest {
         guard let baseURL else {
             logger.error("invalid base URL")
             throw RemoteCompletionsChatClient.Error.invalidURL
@@ -90,6 +98,12 @@ struct RemoteCompletionsChatRequestBuilder {
                 withJSONObject: originalDictionary,
                 options: [.sortedKeys]
             )
+        }
+
+        // pre_process script (if any) gets the last word — it may rewrite
+        // headers and body before URLSession sees the request.
+        if let preProcessor {
+            request = try preProcessor.apply(to: request)
         }
 
         return request

--- a/Sources/ChatClientKit/RemoteCompletionsChatClient/RemoteCompletionsChatStreamProcessor.swift
+++ b/Sources/ChatClientKit/RemoteCompletionsChatClient/RemoteCompletionsChatStreamProcessor.swift
@@ -72,6 +72,12 @@ struct RemoteCompletionsChatStreamProcessor {
                         // Path A: scripting active — let JS produce
                         // (reasoning, content, tool_calls).
                         if let postProcessor {
+                            // Always surface provider-level errors so they
+                            // reach errorCollector even when scripting is on.
+                            if let decodeError = errorExtractor.extractError(from: data) {
+                                await collectError(decodeError)
+                            }
+
                             let parsed = nativeParse(
                                 data: data,
                                 chunkDecoder: chunkDecoder,
@@ -86,20 +92,18 @@ struct RemoteCompletionsChatStreamProcessor {
                                     rawLine: rawLine
                                 )
                             } catch {
-                                await collectError(error)
                                 consecutivePostProcessFailures += 1
                                 if consecutivePostProcessFailures >= 3 {
-                                    // Round 1 impl-review MED #6 fix:
-                                    // surface a clear terminal error so
-                                    // callers don't see partial output as
-                                    // success. AsyncStream can't throw, so
-                                    // we collect the error before finish().
+                                    // Collect terminal error only after 3 consecutive
+                                    // failures; transient failures (1 or 2) are not
+                                    // collected so a later success doesn't surface them.
                                     await collectError(ScriptingStreamError.consecutivePostProcessFailures(
                                         count: consecutivePostProcessFailures, last: error
                                     ))
                                     continuation.finish()
                                     break eventLoop
                                 }
+                                logger.warning("post_process failed (attempt \(consecutivePostProcessFailures)/3), will retry: \(error.localizedDescription)")
                                 continue
                             }
                             consecutivePostProcessFailures = 0

--- a/Sources/ChatClientKit/RemoteCompletionsChatClient/RemoteCompletionsChatStreamProcessor.swift
+++ b/Sources/ChatClientKit/RemoteCompletionsChatClient/RemoteCompletionsChatStreamProcessor.swift
@@ -89,6 +89,14 @@ struct RemoteCompletionsChatStreamProcessor {
                                 await collectError(error)
                                 consecutivePostProcessFailures += 1
                                 if consecutivePostProcessFailures >= 3 {
+                                    // Round 1 impl-review MED #6 fix:
+                                    // surface a clear terminal error so
+                                    // callers don't see partial output as
+                                    // success. AsyncStream can't throw, so
+                                    // we collect the error before finish().
+                                    await collectError(ScriptingStreamError.consecutivePostProcessFailures(
+                                        count: consecutivePostProcessFailures, last: error
+                                    ))
                                     continuation.finish()
                                     break eventLoop
                                 }

--- a/Sources/ChatClientKit/RemoteCompletionsChatClient/RemoteCompletionsChatStreamProcessor.swift
+++ b/Sources/ChatClientKit/RemoteCompletionsChatClient/RemoteCompletionsChatStreamProcessor.swift
@@ -13,17 +13,20 @@ struct RemoteCompletionsChatStreamProcessor {
     let chunkDecoder: JSONDecoding
     let errorExtractor: RemoteCompletionsChatErrorExtractor
     let reasoningParser: CompletionReasoningDecoder
+    let postProcessor: PostProcessor?
 
     init(
         eventSourceFactory: EventSourceProducing = DefaultEventSourceFactory(),
         chunkDecoder: JSONDecoding = JSONDecoderWrapper(),
         errorExtractor: RemoteCompletionsChatErrorExtractor = RemoteCompletionsChatErrorExtractor(),
-        reasoningParser: CompletionReasoningDecoder = .init()
+        reasoningParser: CompletionReasoningDecoder = .init(),
+        postProcessor: PostProcessor? = nil
     ) {
         self.eventSourceFactory = eventSourceFactory
         self.chunkDecoder = chunkDecoder
         self.errorExtractor = errorExtractor
         self.reasoningParser = reasoningParser
+        self.postProcessor = postProcessor
     }
 
     func stream(
@@ -34,18 +37,21 @@ struct RemoteCompletionsChatStreamProcessor {
         let chunkDecoder = chunkDecoder
         let errorExtractor = errorExtractor
         let reasoningParser = reasoningParser
+        let postProcessor = postProcessor
 
         let stream = AsyncStream<ChatResponseChunk> { continuation in
-            Task.detached(priority: .userInitiated) { [collectError, eventSourceFactory, chunkDecoder, errorExtractor, reasoningParser, request] in
+            Task.detached(priority: .userInitiated) { [collectError, eventSourceFactory, chunkDecoder, errorExtractor, reasoningParser, postProcessor, request] in
                 var canDecodeReasoningContent = true
                 var reducer = ReasoningStreamReducer(parser: reasoningParser)
                 let toolCallCollector = CompletionToolCollector()
                 var chunkCount = 0
                 var totalContentLength = 0
+                // post_process 连续失败计数(plan §7,Round 2 codex HIGH #7)
+                var consecutivePostProcessFailures = 0
 
                 let streamTask = eventSourceFactory.makeDataTask(for: request)
 
-                for await event in streamTask.events() {
+                eventLoop: for await event in streamTask.events() {
                     switch event {
                     case .open:
                         logger.info("connection was opened.")
@@ -53,16 +59,57 @@ struct RemoteCompletionsChatStreamProcessor {
                         logger.error("received an error: \(error)")
                         await collectError(error)
                     case let .event(event):
-                        guard let data = event.data?.data(using: .utf8) else {
+                        guard let rawLine = event.data,
+                              let data = rawLine.data(using: .utf8)
+                        else {
                             continue
                         }
-                        if let text = String(data: data, encoding: .utf8),
-                           text.lowercased() == "[done]".lowercased()
-                        {
+                        if rawLine.lowercased() == "[done]" {
                             logger.debug("received done from upstream")
                             continue
                         }
 
+                        // Path A: scripting active — let JS produce
+                        // (reasoning, content, tool_calls).
+                        if let postProcessor {
+                            let parsed = nativeParse(
+                                data: data,
+                                chunkDecoder: chunkDecoder,
+                                reasoningParser: reasoningParser,
+                                canDecodeReasoning: &canDecodeReasoningContent,
+                                reducer: &reducer
+                            )
+                            let out: PostProcessOutput
+                            do {
+                                out = try postProcessor.process(
+                                    parsed: parsed ?? PostProcessOutput(),
+                                    rawLine: rawLine
+                                )
+                            } catch {
+                                await collectError(error)
+                                consecutivePostProcessFailures += 1
+                                if consecutivePostProcessFailures >= 3 {
+                                    continuation.finish()
+                                    break eventLoop
+                                }
+                                continue
+                            }
+                            consecutivePostProcessFailures = 0
+                            chunkCount += 1
+                            if let r = out.reasoning, !r.isEmpty {
+                                continuation.yield(.reasoning(r))
+                            }
+                            if let c = out.content {
+                                totalContentLength += c.count
+                                continuation.yield(.text(c))
+                            }
+                            for t in out.toolCalls ?? [] {
+                                continuation.yield(.tool(ToolRequest(id: t.id, name: t.name, args: t.args)))
+                            }
+                            continue
+                        }
+
+                        // Path B: native (no scripting).
                         do {
                             var response = try chunkDecoder.decode(ChatCompletionChunk.self, from: data)
 
@@ -122,28 +169,89 @@ struct RemoteCompletionsChatStreamProcessor {
                     }
                 }
 
-                for leftover in reducer.flushRemaining() {
-                    for choice in leftover.choices {
-                        let reasoning = choice.delta.reasoningContent ?? choice.delta.reasoning
-                        if let reasoning, !reasoning.isEmpty {
-                            continuation.yield(.reasoning(reasoning))
-                        }
-                        if let content = choice.delta.content {
-                            continuation.yield(.text(content))
+                // Native-path-only: drain reducer + tool collector. With
+                // scripting enabled, the JS is responsible for emitting
+                // any leftover state in its own chunks.
+                if postProcessor == nil {
+                    for leftover in reducer.flushRemaining() {
+                        for choice in leftover.choices {
+                            let reasoning = choice.delta.reasoningContent ?? choice.delta.reasoning
+                            if let reasoning, !reasoning.isEmpty {
+                                continuation.yield(.reasoning(reasoning))
+                            }
+                            if let content = choice.delta.content {
+                                continuation.yield(.text(content))
+                            }
                         }
                     }
-                }
 
-                toolCallCollector.finalizeCurrentDeltaContent()
-                for call in toolCallCollector.pendingRequests {
-                    continuation.yield(.tool(call))
+                    toolCallCollector.finalizeCurrentDeltaContent()
+                    for call in toolCallCollector.pendingRequests {
+                        continuation.yield(.tool(call))
+                    }
+                    logger.info("streaming completed: received \(chunkCount) chunks, total content length: \(totalContentLength), tool calls: \(toolCallCollector.pendingRequests.count)")
+                } else {
+                    logger.info("streaming completed via scripting: received \(chunkCount) chunks, total content length: \(totalContentLength)")
                 }
-                logger.info("streaming completed: received \(chunkCount) chunks, total content length: \(totalContentLength), tool calls: \(toolCallCollector.pendingRequests.count)")
                 continuation.finish()
             }
         }
         return stream.eraseToAnyAsyncSequence()
     }
+}
+
+/// Decode one SSE-data chunk into a `PostProcessOutput` for inherit=true
+/// path. Returns nil if the chunk doesn't parse (silently swallowed —
+/// inherit=true scripts get an empty `parsed` and can fall back to
+/// `chatSession` or other state).
+private func nativeParse(
+    data: Data,
+    chunkDecoder: JSONDecoding,
+    reasoningParser _: CompletionReasoningDecoder,
+    canDecodeReasoning: inout Bool,
+    reducer: inout ReasoningStreamReducer
+) -> PostProcessOutput? {
+    guard var response = try? chunkDecoder.decode(ChatCompletionChunk.self, from: data) else {
+        return nil
+    }
+
+    let reasoningContent = [
+        response.choices.map(\.delta).compactMap(\.reasoning),
+        response.choices.map(\.delta).compactMap(\.reasoningContent),
+    ].flatMap(\.self).filter { !$0.isEmpty }
+    if canDecodeReasoning, !reasoningContent.isEmpty {
+        canDecodeReasoning = false
+    }
+    if canDecodeReasoning {
+        let contentSegments = response.choices.map(\.delta).compactMap(\.content)
+        reducer.process(contentSegments: contentSegments, into: &response)
+    }
+
+    var reasoning: String?
+    var content: String?
+    var toolCalls: [PostProcessOutput.ToolCall] = []
+    for choice in response.choices {
+        if let r = choice.delta.reasoningContent ?? choice.delta.reasoning, !r.isEmpty {
+            reasoning = (reasoning ?? "") + r
+        }
+        if let c = choice.delta.content {
+            content = (content ?? "") + c
+        }
+        for t in choice.delta.toolCalls ?? [] {
+            if let fn = t.function, let name = fn.name {
+                toolCalls.append(.init(
+                    id: t.id ?? UUID().uuidString,
+                    name: name,
+                    args: fn.arguments ?? "{}"
+                ))
+            }
+        }
+    }
+    return PostProcessOutput(
+        reasoning: reasoning,
+        content: content,
+        toolCalls: toolCalls.isEmpty ? nil : toolCalls
+    )
 }
 
 private func parseDataURL(_ text: String) -> (data: Data, mimeType: String?)? {

--- a/Sources/ChatClientKit/RemoteResponsesChatClient/RemoteResponsesChatClient.swift
+++ b/Sources/ChatClientKit/RemoteResponsesChatClient/RemoteResponsesChatClient.swift
@@ -72,15 +72,34 @@ public class RemoteResponsesChatClient: ChatService, @unchecked Sendable {
     public func streamingChat(
         body: ChatRequestBody
     ) async throws -> AnyAsyncSequence<ChatResponseChunk> {
+        try await streamingChat(body: body, scripting: nil)
+    }
+
+    public func streamingChat(
+        body: ChatRequestBody,
+        scripting: ChatScriptingHandle?
+    ) async throws -> AnyAsyncSequence<ChatResponseChunk> {
         let requestBody = resolve(body: body, stream: true)
-        let request = try makeURLRequest(body: requestBody)
+
+        let runtime: ScriptRuntime?
+        if let scripting, scripting.config.hasAnyStage {
+            runtime = try ScriptRuntime.make(body: body, handle: scripting)
+        } else {
+            runtime = nil
+        }
+
+        let request = try makeURLRequest(
+            body: requestBody,
+            preProcessor: runtime?.preProcessor
+        )
         let this = self
         logger.info("starting streaming responses request to model: \(this.model) with \(body.messages.count) messages, temperature: \(body.temperature ?? 1.0)")
 
         let processor = RemoteResponsesChatStreamProcessor(
             eventSourceFactory: eventSourceFactory,
             chunkDecoder: chunkDecoderFactory(),
-            errorExtractor: errorExtractor
+            errorExtractor: errorExtractor,
+            postProcessor: runtime?.postProcessor
         )
 
         return processor.stream(request: request) { [weak self] error in
@@ -100,8 +119,19 @@ extension RemoteResponsesChatClient {
     }
 
     func makeURLRequest(body: ResponsesRequestBody) throws -> URLRequest {
+        try makeURLRequest(body: body, preProcessor: nil)
+    }
+
+    func makeURLRequest(
+        body: ResponsesRequestBody,
+        preProcessor: PreProcessor?
+    ) throws -> URLRequest {
         let builder = makeRequestBuilder()
-        return try builder.makeRequest(body: body, additionalField: additionalBodyField)
+        return try builder.makeRequest(
+            body: body,
+            additionalField: additionalBodyField,
+            preProcessor: preProcessor
+        )
     }
 
     func resolve(body: ChatRequestBody, stream: Bool) -> ResponsesRequestBody {

--- a/Sources/ChatClientKit/RemoteResponsesChatClient/RemoteResponsesChatClient.swift
+++ b/Sources/ChatClientKit/RemoteResponsesChatClient/RemoteResponsesChatClient.swift
@@ -79,11 +79,14 @@ public class RemoteResponsesChatClient: ChatService, @unchecked Sendable {
         body: ChatRequestBody,
         scripting: ChatScriptingHandle?
     ) async throws -> AnyAsyncSequence<ChatResponseChunk> {
-        let requestBody = resolve(body: body, stream: true)
+        // Resolve to the sanitized ChatRequestBody first so chatSession in JS
+        // reflects the same model/stream fields as the actual HTTP request.
+        let resolvedChat = sanitizeChat(body: body, stream: true)
+        let requestBody = requestTransformer.makeRequestBody(from: resolvedChat, model: model, stream: true)
 
         let runtime: ScriptRuntime?
         if let scripting, scripting.config.hasAnyStage {
-            runtime = try ScriptRuntime.make(body: body, handle: scripting)
+            runtime = try ScriptRuntime.make(body: resolvedChat, handle: scripting)
         } else {
             runtime = nil
         }
@@ -134,11 +137,18 @@ extension RemoteResponsesChatClient {
         )
     }
 
+    /// Merge adjacent assistant messages, set model/stream, and sanitize.
+    /// Returns the sanitized `ChatRequestBody` used both for `ScriptRuntime`
+    /// and as the source for `requestTransformer`.
+    func sanitizeChat(body: ChatRequestBody, stream: Bool) -> ChatRequestBody {
+        var resolved = body.mergingAdjacentAssistantMessages()
+        resolved.model = model
+        resolved.stream = stream
+        return requestSanitizer.sanitize(resolved)
+    }
+
     func resolve(body: ChatRequestBody, stream: Bool) -> ResponsesRequestBody {
-        var requestBody = body.mergingAdjacentAssistantMessages()
-        requestBody.model = model
-        requestBody.stream = stream
-        let sanitized = requestSanitizer.sanitize(requestBody)
+        let sanitized = sanitizeChat(body: body, stream: stream)
         return requestTransformer.makeRequestBody(from: sanitized, model: model, stream: stream)
     }
 

--- a/Sources/ChatClientKit/RemoteResponsesChatClient/RemoteResponsesChatRequestBuilder.swift
+++ b/Sources/ChatClientKit/RemoteResponsesChatClient/RemoteResponsesChatRequestBuilder.swift
@@ -33,6 +33,14 @@ struct RemoteResponsesRequestBuilder {
         body: ResponsesRequestBody,
         additionalField: [String: Any]
     ) throws -> URLRequest {
+        try makeRequest(body: body, additionalField: additionalField, preProcessor: nil)
+    }
+
+    func makeRequest(
+        body: ResponsesRequestBody,
+        additionalField: [String: Any],
+        preProcessor: PreProcessor?
+    ) throws -> URLRequest {
         guard let baseURL else {
             logger.error("invalid base URL for responses client")
             throw RemoteResponsesChatClient.Error.invalidURL
@@ -86,6 +94,11 @@ struct RemoteResponsesRequestBuilder {
                 withJSONObject: originalDictionary,
                 options: [.sortedKeys]
             )
+        }
+
+        // pre_process script gets the last word (mirror of completions builder).
+        if let preProcessor {
+            request = try preProcessor.apply(to: request)
         }
 
         logger.debug("constructed responses request URL: \(url.absoluteString)")

--- a/Sources/ChatClientKit/RemoteResponsesChatClient/RemoteResponsesChatStreamProcessor.swift
+++ b/Sources/ChatClientKit/RemoteResponsesChatClient/RemoteResponsesChatStreamProcessor.swift
@@ -101,6 +101,10 @@ struct RemoteResponsesChatStreamProcessor {
                                 await collectError(error)
                                 consecutivePostProcessFailures += 1
                                 if consecutivePostProcessFailures >= 3 {
+                                    // Round 1 impl-review MED #6 (responses): make terminal failure visible.
+                                    await collectError(ScriptingStreamError.consecutivePostProcessFailures(
+                                        count: consecutivePostProcessFailures, last: error
+                                    ))
                                     continuation.finish()
                                     break eventLoop
                                 }

--- a/Sources/ChatClientKit/RemoteResponsesChatClient/RemoteResponsesChatStreamProcessor.swift
+++ b/Sources/ChatClientKit/RemoteResponsesChatClient/RemoteResponsesChatStreamProcessor.swift
@@ -12,15 +12,18 @@ struct RemoteResponsesChatStreamProcessor {
     let eventSourceFactory: EventSourceProducing
     let chunkDecoder: JSONDecoding
     let errorExtractor: RemoteResponsesChatErrorExtractor
+    let postProcessor: PostProcessor?
 
     init(
         eventSourceFactory: EventSourceProducing = DefaultEventSourceFactory(),
         chunkDecoder: JSONDecoding = JSONDecoderWrapper(),
-        errorExtractor: RemoteResponsesChatErrorExtractor = RemoteResponsesChatErrorExtractor()
+        errorExtractor: RemoteResponsesChatErrorExtractor = RemoteResponsesChatErrorExtractor(),
+        postProcessor: PostProcessor? = nil
     ) {
         self.eventSourceFactory = eventSourceFactory
         self.chunkDecoder = chunkDecoder
         self.errorExtractor = errorExtractor
+        self.postProcessor = postProcessor
     }
 
     func stream(
@@ -28,7 +31,7 @@ struct RemoteResponsesChatStreamProcessor {
         collectError: @Sendable @escaping (Swift.Error) async -> Void
     ) -> AnyAsyncSequence<ChatResponseChunk> {
         let stream = AsyncStream<ChatResponseChunk> { continuation in
-            Task.detached(priority: .userInitiated) { [collectError, eventSourceFactory, chunkDecoder, errorExtractor, request] in
+            Task.detached(priority: .userInitiated) { [collectError, eventSourceFactory, chunkDecoder, errorExtractor, postProcessor, request] in
                 var toolCollector = ResponsesToolCallCollector()
                 var outputMetadata: [String: OutputItemMetadata] = [:]
                 var streamedTextItemIDs: Set<String> = []
@@ -36,10 +39,11 @@ struct RemoteResponsesChatStreamProcessor {
                 var chunkCount = 0
                 var totalContentLength = 0
                 var ignoredToolEvents: Set<String> = []
+                var consecutivePostProcessFailures = 0
 
                 let streamTask = eventSourceFactory.makeDataTask(for: request)
 
-                for await event in streamTask.events() {
+                eventLoop: for await event in streamTask.events() {
                     switch event {
                     case .open:
                         logger.info("responses stream connection opened.")
@@ -47,12 +51,12 @@ struct RemoteResponsesChatStreamProcessor {
                         logger.error("received responses stream error: \(error.localizedDescription)")
                         await collectError(error)
                     case let .event(event):
-                        guard let data = event.data?.data(using: .utf8) else {
+                        guard let rawLine = event.data,
+                              let data = rawLine.data(using: .utf8)
+                        else {
                             continue
                         }
-                        if let text = String(data: data, encoding: .utf8),
-                           text.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() == "[DONE]"
-                        {
+                        if rawLine.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() == "[DONE]" {
                             logger.debug("received [DONE] from responses stream")
                             continue
                         }
@@ -62,6 +66,62 @@ struct RemoteResponsesChatStreamProcessor {
                             continue
                         }
 
+                        // Scripting active — let JS produce the chunk.
+                        if let postProcessor {
+                            // Best-effort native parse to a PostProcessOutput for
+                            // inherit=true path. On parse failure pass empty parsed.
+                            var parsed = PostProcessOutput()
+                            if let payload = try? chunkDecoder.decode(ResponsesStreamEvent.self, from: data) {
+                                if let chunk = handle(
+                                    payload: payload,
+                                    toolCollector: &toolCollector,
+                                    outputMetadata: &outputMetadata,
+                                    streamedTextItemIDs: &streamedTextItemIDs,
+                                    ignoredToolEvents: &ignoredToolEvents,
+                                    finishEmitted: &finishReasonEmitted
+                                ) {
+                                    var reasoning: String?
+                                    var content: String?
+                                    for choice in chunk.choices {
+                                        if let r = choice.delta.reasoningContent {
+                                            reasoning = (reasoning ?? "") + r
+                                        }
+                                        if let c = choice.delta.content {
+                                            content = (content ?? "") + c
+                                        }
+                                    }
+                                    parsed = PostProcessOutput(reasoning: reasoning, content: content, toolCalls: nil)
+                                }
+                            }
+
+                            let out: PostProcessOutput
+                            do {
+                                out = try postProcessor.process(parsed: parsed, rawLine: rawLine)
+                            } catch {
+                                await collectError(error)
+                                consecutivePostProcessFailures += 1
+                                if consecutivePostProcessFailures >= 3 {
+                                    continuation.finish()
+                                    break eventLoop
+                                }
+                                continue
+                            }
+                            consecutivePostProcessFailures = 0
+                            chunkCount += 1
+                            if let r = out.reasoning, !r.isEmpty {
+                                continuation.yield(.reasoning(r))
+                            }
+                            if let c = out.content {
+                                totalContentLength += c.count
+                                continuation.yield(.text(c))
+                            }
+                            for t in out.toolCalls ?? [] {
+                                continuation.yield(.tool(ToolRequest(id: t.id, name: t.name, args: t.args)))
+                            }
+                            continue
+                        }
+
+                        // Native path (no scripting).
                         do {
                             let payload = try chunkDecoder.decode(ResponsesStreamEvent.self, from: data)
 
@@ -109,11 +169,16 @@ struct RemoteResponsesChatStreamProcessor {
                     _ = hasTools // terminal reason only; no chunk emitted
                 }
 
-                let pendingCalls = toolCollector.finalizeRequests()
-                for call in pendingCalls {
-                    continuation.yield(.tool(call))
+                // Native-only tail: with scripting on, JS already drove tool yielding.
+                if postProcessor == nil {
+                    let pendingCalls = toolCollector.finalizeRequests()
+                    for call in pendingCalls {
+                        continuation.yield(.tool(call))
+                    }
+                    logger.info("responses streaming completed: received \(chunkCount) chunks, total content length: \(totalContentLength), tool calls: \(pendingCalls.count), ignored tool-like events: \(ignoredToolEvents.count)")
+                } else {
+                    logger.info("responses streaming completed via scripting: received \(chunkCount) chunks, total content length: \(totalContentLength)")
                 }
-                logger.info("responses streaming completed: received \(chunkCount) chunks, total content length: \(totalContentLength), tool calls: \(pendingCalls.count), ignored tool-like events: \(ignoredToolEvents.count)")
                 continuation.finish()
             }
         }

--- a/Sources/ChatClientKit/RemoteResponsesChatClient/RemoteResponsesChatStreamProcessor.swift
+++ b/Sources/ChatClientKit/RemoteResponsesChatClient/RemoteResponsesChatStreamProcessor.swift
@@ -98,16 +98,18 @@ struct RemoteResponsesChatStreamProcessor {
                             do {
                                 out = try postProcessor.process(parsed: parsed, rawLine: rawLine)
                             } catch {
-                                await collectError(error)
                                 consecutivePostProcessFailures += 1
                                 if consecutivePostProcessFailures >= 3 {
-                                    // Round 1 impl-review MED #6 (responses): make terminal failure visible.
+                                    // Collect terminal error only after 3 consecutive
+                                    // failures; transient failures (1 or 2) are not
+                                    // collected so a later success doesn't surface them.
                                     await collectError(ScriptingStreamError.consecutivePostProcessFailures(
                                         count: consecutivePostProcessFailures, last: error
                                     ))
                                     continuation.finish()
                                     break eventLoop
                                 }
+                                logger.warning("post_process failed (attempt \(consecutivePostProcessFailures)/3), will retry: \(error.localizedDescription)")
                                 continue
                             }
                             consecutivePostProcessFailures = 0

--- a/Sources/ChatClientKit/Scripting/ChatClientKitScriptConfig.swift
+++ b/Sources/ChatClientKit/Scripting/ChatClientKitScriptConfig.swift
@@ -1,0 +1,67 @@
+//
+//  ChatClientKitScriptConfig.swift
+//  ChatClientKit
+//
+//  Strong-typed view of the plist-encoded blob stored at
+//  `CloudModel.ext_data["chat_client_kit_scripts"]`.
+//
+//  Top-level shape:
+//      <dict>
+//        <key>pre_process</key>
+//        <dict>
+//          <key>inherit</key> <true/>
+//          <key>script</key>  <string>/* js */</string>
+//        </dict>
+//        <key>post_process</key>
+//        <dict>
+//          <key>inherit</key> <false/>
+//          <key>script</key>  <string>/* js */</string>
+//        </dict>
+//      </dict>
+//
+
+import Foundation
+
+public struct ChatClientKitScriptConfig: Codable, Sendable, Equatable {
+    public struct Stage: Codable, Sendable, Equatable {
+        public var inherit: Bool
+        public var script: String
+
+        public init(inherit: Bool, script: String) {
+            self.inherit = inherit
+            self.script = script
+        }
+    }
+
+    public var preProcess: Stage?
+    public var postProcess: Stage?
+
+    public init(preProcess: Stage? = nil, postProcess: Stage? = nil) {
+        self.preProcess = preProcess
+        self.postProcess = postProcess
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case preProcess = "pre_process"
+        case postProcess = "post_process"
+    }
+}
+
+public extension ChatClientKitScriptConfig {
+    /// Decode from the plist string typically stored in
+    /// `CloudModel.ext_data[ExtensionKey.chatClientKitScripts]`.
+    ///
+    /// Returns `nil` if the string is empty or malformed — caller should
+    /// treat that as "scripting disabled".
+    static func decodePList(_ string: String) -> Self? {
+        guard !string.isEmpty,
+              let data = string.data(using: .utf8)
+        else { return nil }
+        return try? PropertyListDecoder().decode(Self.self, from: data)
+    }
+
+    /// Whether any stage is configured. Convenience for the call site.
+    var hasAnyStage: Bool {
+        preProcess != nil || postProcess != nil
+    }
+}

--- a/Sources/ChatClientKit/Scripting/ChatScriptingHandle.swift
+++ b/Sources/ChatClientKit/Scripting/ChatScriptingHandle.swift
@@ -1,0 +1,48 @@
+//
+//  ChatScriptingHandle.swift
+//  ChatClientKit
+//
+//  Connector struct passed by the FlowDown app to a ChatService.streamingChat
+//  call when the model has scripting configured. ChatClientKit does NOT
+//  depend on Storage; the app builds the handle from CloudModel + Conversation
+//  via the ChatScriptingAdapter in the app target.
+//
+
+import Foundation
+
+public struct ChatScriptingHandle: @unchecked Sendable {
+    /// Stable identifier for the conversation the script runs in.
+    public let conversationId: String
+
+    /// Decoded plist-config from `CloudModel.ext_data[chat_client_kit_scripts]`.
+    public let config: ChatClientKitScriptConfig
+
+    /// Manifest snapshot — adapter constructs this via a whitelist
+    /// (sensitive fields like token are NOT included).
+    public let manifest: ManifestSnapshot
+
+    /// Read the current per-conversation context blob.
+    /// Adapter's typical implementation:
+    ///   `sdb.conversationWith(identifier: id)?.ext_data[ExtensionKey.chatClientKit] ?? ""`
+    public let readContext: @Sendable () -> String
+
+    /// Synchronous write of the context blob.
+    /// **Caller invariant**: must not be invoked while holding any WCDB
+    /// transaction in the streamingChat caller chain — risk of lock
+    /// inversion. See plan §8.4.
+    public let writeContext: @Sendable (String) throws -> Void
+
+    public init(
+        conversationId: String,
+        config: ChatClientKitScriptConfig,
+        manifest: ManifestSnapshot,
+        readContext: @escaping @Sendable () -> String,
+        writeContext: @escaping @Sendable (String) throws -> Void
+    ) {
+        self.conversationId = conversationId
+        self.config = config
+        self.manifest = manifest
+        self.readContext = readContext
+        self.writeContext = writeContext
+    }
+}

--- a/Sources/ChatClientKit/Scripting/PostProcessor.swift
+++ b/Sources/ChatClientKit/Scripting/PostProcessor.swift
@@ -1,0 +1,62 @@
+//
+//  PostProcessor.swift
+//  ChatClientKit
+//
+//  Wraps a ScriptRunner.invoke for the `post_process` stage. Called
+//  once per SSE chunk that the StreamProcessor consumes.
+//
+//  Two modes:
+//   - inherit=true:  Swift first parses the chunk into
+//                    {reasoning, content, tool_calls}; JS sees that obj
+//                    and returns a (possibly modified) PostProcessOutput.
+//   - inherit=false: JS sees the raw `line` string (already stripped of
+//                    `data:` prefix by ServerSentEvent.parse) and is
+//                    responsible for parsing it itself.
+//
+
+import Foundation
+
+struct PostProcessor {
+    let runner: ScriptRunner
+    let stage: ChatClientKitScriptConfig.Stage
+
+    /// inherit=true path. Feeds parsed payload to JS.
+    func processParsed(_ parsed: PostProcessOutput) throws -> PostProcessOutput {
+        guard stage.inherit else {
+            // Caller used the wrong path; defensively forward unchanged.
+            return parsed
+        }
+        let bindings: [String: Any] = try [
+            "parsed": toJSAny(parsed),
+        ]
+        return try runner.invoke(
+            script: stage.script,
+            bindings: bindings
+        )
+    }
+
+    /// inherit=false path. Feeds raw SSE-data line to JS.
+    func processRawLine(_ line: String) throws -> PostProcessOutput {
+        let bindings: [String: Any] = [
+            "line": line,
+        ]
+        return try runner.invoke(
+            script: stage.script,
+            bindings: bindings
+        )
+    }
+
+    /// Convenience: choose path based on stage.inherit.
+    func process(parsed: PostProcessOutput, rawLine: String) throws -> PostProcessOutput {
+        if stage.inherit {
+            try processParsed(parsed)
+        } else {
+            try processRawLine(rawLine)
+        }
+    }
+
+    private func toJSAny<T: Encodable>(_ value: T) throws -> Any {
+        let data = try JSONEncoder().encode(value)
+        return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+    }
+}

--- a/Sources/ChatClientKit/Scripting/PreProcessor.swift
+++ b/Sources/ChatClientKit/Scripting/PreProcessor.swift
@@ -38,7 +38,7 @@ struct PreProcessor {
             inputBody = .object([:])
         }
 
-        let bindings: [String: Any] = try [
+        let bindings: [String: Any] = [
             "headers": try toJSAny(inputHeaders),
             "body": try toJSAny(inputBody),
         ]

--- a/Sources/ChatClientKit/Scripting/PreProcessor.swift
+++ b/Sources/ChatClientKit/Scripting/PreProcessor.swift
@@ -1,0 +1,82 @@
+//
+//  PreProcessor.swift
+//  ChatClientKit
+//
+//  Wraps a ScriptRunner.invoke for the `pre_process` stage. Called once
+//  per request, right before URLSession.dataTask. The result rewrites
+//  the request headers (in script-provided order) and HTTP body.
+//
+
+import Foundation
+
+struct PreProcessor {
+    let runner: ScriptRunner
+    let stage: ChatClientKitScriptConfig.Stage
+
+    /// Run pre_process on a constructed URLRequest.
+    ///
+    /// - inherit=true: feeds JS the current headers + body (from
+    ///   our normal build flow). JS may tweak / re-sign / re-order.
+    /// - inherit=false: feeds JS empty headers + empty body. JS
+    ///   constructs everything from `chatSession` / `manifest`.
+    ///
+    /// Returns a mutated URLRequest: headers are wiped and re-set in
+    /// JS-provided order, body becomes the JSON-encoded
+    /// PreProcessOutput.body.
+    func apply(to request: URLRequest) throws -> URLRequest {
+        var mutated = request
+
+        let inputHeaders: ScriptHeaderList
+        let inputBody: AnyCodingValue
+        if stage.inherit {
+            inputHeaders = ScriptHeaderList(
+                entries: orderedHeaderEntries(from: mutated)
+            )
+            inputBody = decodeBody(mutated.httpBody)
+        } else {
+            inputHeaders = ScriptHeaderList(entries: [])
+            inputBody = .object([:])
+        }
+
+        let bindings: [String: Any] = try [
+            "headers": try toJSAny(inputHeaders),
+            "body": try toJSAny(inputBody),
+        ]
+        let out: PreProcessOutput = try runner.invoke(
+            script: stage.script,
+            bindings: bindings
+        )
+
+        // Wipe and re-set headers in JS-given order.
+        mutated.allHTTPHeaderFields = nil
+        for entry in out.headers.entries {
+            mutated.setValue(entry.value, forHTTPHeaderField: entry.name)
+        }
+
+        // Replace body with JS output.
+        let bodyData = try JSONEncoder().encode(out.body)
+        mutated.httpBody = bodyData
+
+        return mutated
+    }
+
+    private func orderedHeaderEntries(from request: URLRequest) -> [ScriptHeaderList.Entry] {
+        // URLRequest.allHTTPHeaderFields is a Dictionary — we can't
+        // guarantee on-the-wire order (see plan §1.6). Sort by name
+        // to at least give scripts a deterministic input order.
+        let raw = request.allHTTPHeaderFields ?? [:]
+        return raw.keys.sorted().map { key in
+            ScriptHeaderList.Entry(name: key, value: raw[key] ?? "")
+        }
+    }
+
+    private func decodeBody(_ data: Data?) -> AnyCodingValue {
+        guard let data, !data.isEmpty else { return .object([:]) }
+        return (try? JSONDecoder().decode(AnyCodingValue.self, from: data)) ?? .object([:])
+    }
+
+    private func toJSAny<T: Encodable>(_ value: T) throws -> Any {
+        let data = try JSONEncoder().encode(value)
+        return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+    }
+}

--- a/Sources/ChatClientKit/Scripting/ScriptBridge.swift
+++ b/Sources/ChatClientKit/Scripting/ScriptBridge.swift
@@ -1,0 +1,130 @@
+//
+//  ScriptBridge.swift
+//  ChatClientKit
+//
+//  Bridge object exposed to JavaScript as the global `cck`.
+//  Includes saveContext (synchronous persistence with 5s watchdog),
+//  log, and a small set of crypto / encoding utilities.
+//
+//  Watchdog semantics(plan §1.8/§8.4):若 onWriteContext > 5s
+//  无返回(典型场景:外层调用方持有 WCDB transaction → 锁反转),
+//  直接 fatalError 让进程死,不允许挂屏。
+//
+
+import CommonCrypto
+import Foundation
+import JavaScriptCore
+
+@objc public protocol ScriptBridgeExports: JSExport {
+    func saveContext(_ value: JSValue)
+    func log(_ message: String)
+    func base64Encode(_ s: String) -> String
+    func base64Decode(_ s: String) -> String
+    func sha256(_ s: String) -> String
+    func hmacSHA256(_ key: String, message: String) -> String
+}
+
+public final class ScriptBridge: NSObject, ScriptBridgeExports, @unchecked Sendable {
+    /// Synchronous-semantics write back to durable storage.
+    /// Throws are caught and surfaced to the JS side as exceptions.
+    /// **Caller responsibility**: closure must be self-contained,
+    /// not nested inside any DB transaction held by the streamingChat
+    /// caller chain (see plan §8.4 — risk of lock inversion).
+    let onWriteContext: @Sendable (String) throws -> Void
+
+    /// How long Swift will wait synchronously for the write closure to
+    /// complete before forcing the process down. Plan §1.8 / §8.4.
+    /// Hardcoded at 5s in production; configurable for tests.
+    let writeTimeout: DispatchTimeInterval
+
+    public init(
+        onWriteContext: @escaping @Sendable (String) throws -> Void,
+        writeTimeout: DispatchTimeInterval = .seconds(5)
+    ) {
+        self.onWriteContext = onWriteContext
+        self.writeTimeout = writeTimeout
+        super.init()
+    }
+
+    // MARK: - JSExport
+
+    @objc public func saveContext(_ value: JSValue) {
+        // 1. Stringify on the JS side. If it throws (e.g. circular refs),
+        //    surface the error to the script.
+        guard let ctx = value.context,
+              let stringifier = ctx.evaluateScript("JSON.stringify"),
+              let json = stringifier.call(withArguments: [value])?.toString(),
+              json != "undefined"
+        else {
+            let ctx = JSContext.current() ?? value.context
+            ctx?.exception = JSValue(
+                newErrorFromMessage: "saveContext: value is not JSON-serializable",
+                in: ctx
+            )
+            return
+        }
+
+        // 2. Cross-queue synchronous wait with 5s budget.
+        //    onWriteContext must run on a DIFFERENT queue than the JS
+        //    script (we're currently on the ScriptRunner's serial queue);
+        //    otherwise we'd deadlock against ourselves.
+        let sem = DispatchSemaphore(value: 0)
+        var caught: Error?
+        DispatchQueue.global(qos: .userInitiated).async { [self] in
+            do { try onWriteContext(json) }
+            catch { caught = error }
+            sem.signal()
+        }
+        if sem.wait(timeout: .now() + writeTimeout) == .timedOut {
+            fatalError(
+                "[CCK] saveContext write blocked > \(writeTimeout) — likely WCDB lock inversion in caller chain"
+            )
+        }
+        if let err = caught {
+            let ctx = JSContext.current() ?? value.context
+            ctx?.exception = JSValue(
+                newErrorFromMessage: "saveContext failed: \(err)",
+                in: ctx
+            )
+        }
+    }
+
+    @objc public func log(_ message: String) {
+        logger.info("[script] \(message)")
+    }
+
+    @objc public func base64Encode(_ s: String) -> String {
+        Data(s.utf8).base64EncodedString()
+    }
+
+    @objc public func base64Decode(_ s: String) -> String {
+        guard let data = Data(base64Encoded: s) else { return "" }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    @objc public func sha256(_ s: String) -> String {
+        let data = Data(s.utf8)
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        data.withUnsafeBytes { ptr in
+            _ = CC_SHA256(ptr.baseAddress, CC_LONG(data.count), &digest)
+        }
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    @objc public func hmacSHA256(_ key: String, message: String) -> String {
+        let keyData = Data(key.utf8)
+        let msgData = Data(message.utf8)
+        var mac = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        keyData.withUnsafeBytes { kBuf in
+            msgData.withUnsafeBytes { mBuf in
+                CCHmac(
+                    CCHmacAlgorithm(kCCHmacAlgSHA256),
+                    kBuf.baseAddress, keyData.count,
+                    mBuf.baseAddress, msgData.count,
+                    &mac
+                )
+            }
+        }
+        return mac.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/ChatClientKit/Scripting/ScriptBridge.swift
+++ b/Sources/ChatClientKit/Scripting/ScriptBridge.swift
@@ -69,10 +69,13 @@ public final class ScriptBridge: NSObject, ScriptBridgeExports, @unchecked Senda
         //    script (we're currently on the ScriptRunner's serial queue);
         //    otherwise we'd deadlock against ourselves.
         let sem = DispatchSemaphore(value: 0)
-        var caught: Error?
+        // Round 1 codex BLOCKER #4 fix:Swift 6 rejects capturing `var caught`
+        // across `DispatchQueue.async`. Use a lock-protected box; semaphore
+        // enforces happens-before but the type system needs explicit guard.
+        let box = WriteResultBox()
         DispatchQueue.global(qos: .userInitiated).async { [self] in
             do { try onWriteContext(json) }
-            catch { caught = error }
+            catch { box.set(error: error) }
             sem.signal()
         }
         if sem.wait(timeout: .now() + writeTimeout) == .timedOut {
@@ -80,7 +83,7 @@ public final class ScriptBridge: NSObject, ScriptBridgeExports, @unchecked Senda
                 "[CCK] saveContext write blocked > \(writeTimeout) — likely WCDB lock inversion in caller chain"
             )
         }
-        if let err = caught {
+        if let err = box.get() {
             let ctx = JSContext.current() ?? value.context
             ctx?.exception = JSValue(
                 newErrorFromMessage: "saveContext failed: \(err)",
@@ -126,5 +129,24 @@ public final class ScriptBridge: NSObject, ScriptBridgeExports, @unchecked Senda
             }
         }
         return mac.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// Lock-protected one-shot result holder used by `ScriptBridge.saveContext`
+/// to ferry the write-back error from the global queue back to the JS thread.
+private final class WriteResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var error: Error?
+
+    func set(error: Error) {
+        lock.lock()
+        self.error = error
+        lock.unlock()
+    }
+
+    func get() -> Error? {
+        lock.lock()
+        defer { lock.unlock() }
+        return error
     }
 }

--- a/Sources/ChatClientKit/Scripting/ScriptIO.swift
+++ b/Sources/ChatClientKit/Scripting/ScriptIO.swift
@@ -1,0 +1,150 @@
+//
+//  ScriptIO.swift
+//  ChatClientKit
+//
+//  Strong-typed boundary between Swift and JavaScriptCore.
+//  All struct-level fields are Codable; the internal `AnyCodingValue`
+//  escape hatch is reserved for genuinely free JSON (body / manifest
+//  payload).
+//
+
+import Foundation
+
+/// Ordered list of headers (name, value) — preserves the order in which
+/// the script wants them set on the URLRequest. Wire-order is not
+/// guaranteed (see plan §1.6), but the insertion order is the best
+/// signal we can pass through `URLRequest.setValue`.
+public struct ScriptHeaderList: Codable, Sendable, Equatable {
+    public struct Entry: Codable, Sendable, Equatable {
+        public var name: String
+        public var value: String
+        public init(name: String, value: String) {
+            self.name = name
+            self.value = value
+        }
+    }
+
+    public var entries: [Entry]
+
+    public init(entries: [Entry] = []) {
+        self.entries = entries
+    }
+}
+
+/// Output of a `pre_process` script invocation.
+/// The script's `__result` must JSON-stringify into this shape.
+public struct PreProcessOutput: Codable, Sendable {
+    public var headers: ScriptHeaderList
+    public var body: AnyCodingValue
+
+    public init(headers: ScriptHeaderList, body: AnyCodingValue) {
+        self.headers = headers
+        self.body = body
+    }
+}
+
+/// Output of a `post_process` script invocation. Any field optional.
+public struct PostProcessOutput: Codable, Sendable {
+    public struct ToolCall: Codable, Sendable, Equatable {
+        public var id: String
+        public var name: String
+        public var args: String // raw JSON string,与 ToolRequest 对齐
+
+        public init(id: String, name: String, args: String) {
+            self.id = id
+            self.name = name
+            self.args = args
+        }
+    }
+
+    public var reasoning: String?
+    public var content: String?
+    public var toolCalls: [ToolCall]?
+
+    public init(
+        reasoning: String? = nil,
+        content: String? = nil,
+        toolCalls: [ToolCall]? = nil
+    ) {
+        self.reasoning = reasoning
+        self.content = content
+        self.toolCalls = toolCalls
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case reasoning, content
+        case toolCalls = "tool_calls"
+    }
+}
+
+/// Snapshot of `ChatRequestBody` injected as the JS global `chatSession`.
+/// Includes message bodies in full (including base64 image content).
+/// **Frozen** in JS via deepFreeze — scripts can read but not mutate.
+public struct ChatSessionSnapshot: Codable, Sendable {
+    public var model: String?
+    public var messages: [AnyCodingValue]
+    public var tools: [AnyCodingValue]?
+    public var stream: Bool?
+    public var temperature: Double?
+    public var maxCompletionTokens: Int?
+
+    public init(
+        model: String? = nil,
+        messages: [AnyCodingValue] = [],
+        tools: [AnyCodingValue]? = nil,
+        stream: Bool? = nil,
+        temperature: Double? = nil,
+        maxCompletionTokens: Int? = nil
+    ) {
+        self.model = model
+        self.messages = messages
+        self.tools = tools
+        self.stream = stream
+        self.temperature = temperature
+        self.maxCompletionTokens = maxCompletionTokens
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case model, messages, tools, stream, temperature
+        case maxCompletionTokens = "max_completion_tokens"
+    }
+}
+
+/// Opaque manifest passed to scripts. **No fields are defined here on
+/// purpose** — adapter layer (FlowDown app) is responsible for
+/// constructing the payload via a whitelist (see plan §1.10 and §8.1).
+/// ChatClientKit does not know about CloudModel and cannot redact.
+public struct ManifestSnapshot: Codable, Sendable {
+    public var payload: AnyCodingValue
+
+    public init(payload: AnyCodingValue) {
+        self.payload = payload
+    }
+}
+
+public extension ChatSessionSnapshot {
+    /// Build from a `ChatRequestBody`. Internal helper for the integration
+    /// path (used by Pre/Post processors).
+    static func make(from body: ChatRequestBody) throws -> ChatSessionSnapshot {
+        // Round-trip through Foundation JSON to project ChatRequestBody (Encodable only)
+        // into `AnyCodingValue` arrays/objects.
+        let data = try JSONEncoder().encode(body)
+        struct Wire: Decodable {
+            var model: String?
+            var messages: [AnyCodingValue]
+            var tools: [AnyCodingValue]?
+            var stream: Bool?
+            var temperature: Double?
+            var max_completion_tokens: Int?
+        }
+        let wire = try JSONDecoder().decode(Wire.self, from: data)
+        return ChatSessionSnapshot(
+            model: wire.model,
+            messages: wire.messages,
+            tools: wire.tools,
+            stream: wire.stream,
+            temperature: wire.temperature,
+            maxCompletionTokens: wire.max_completion_tokens
+        )
+    }
+}

--- a/Sources/ChatClientKit/Scripting/ScriptRunner.swift
+++ b/Sources/ChatClientKit/Scripting/ScriptRunner.swift
@@ -107,18 +107,17 @@ public final class ScriptRunner: @unchecked Sendable {
         decoding _: Output.Type = Output.self
     ) throws -> Output {
         let sem = DispatchSemaphore(value: 0)
-        var jsonResult: String?
-        var jsError: String?
+        // Round 1 codex BLOCKER #3 fix:Swift 6 strict concurrency rejects
+        // capturing `var` across `queue.async` boundaries. Use a lock-protected
+        // box; semaphore guarantees there's no actual concurrent access
+        // between the writer (queue.async closure) and reader (after sem.wait),
+        // but the type system needs us to be explicit.
+        let box = InvocationResultBox()
 
         queue.async { [self] in
             for (key, value) in bindings {
                 ctx.setObject(value, forKeyedSubscript: key as NSString)
             }
-            // Wrapper:
-            //   - Provides a local __result the user script assigns to.
-            //   - Returns JSON.stringify(__result). If __result is
-            //     undefined, JSON.stringify yields undefined as well —
-            //     we detect that on the Swift side.
             let wrapped = """
             (function() {
               var __result = undefined;
@@ -126,28 +125,31 @@ public final class ScriptRunner: @unchecked Sendable {
               ;return JSON.stringify(__result);
             })()
             """
+            var resultString: String?
+            var errorString: String?
             if let value = ctx.evaluateScript(wrapped),
                !value.isUndefined, !value.isNull
             {
-                jsonResult = value.toString()
+                resultString = value.toString()
             }
             if let exception = ctx.exception {
-                jsError = exception.toString()
+                errorString = exception.toString()
                 ctx.exception = nil
             }
+            box.set(json: resultString, error: errorString)
             sem.signal()
         }
 
         if sem.wait(timeout: .now() + invokeTimeout) == .timedOut {
             // Plan §1.8 — only way to free the queue is to kill the process.
-            // No `onTimeout` closure injection; would only mislead tests.
             fatalError(
                 "ChatClientKit script exceeded \(invokeTimeout) budget — developer must fix the script. Process is doomed."
             )
         }
 
-        if let err = jsError { throw ScriptRunnerError.jsException(err) }
-        guard let json = jsonResult, json != "undefined" else {
+        let snapshot = box.get()
+        if let err = snapshot.error { throw ScriptRunnerError.jsException(err) }
+        guard let json = snapshot.json, json != "undefined" else {
             throw ScriptRunnerError.noOutput
         }
         do {
@@ -186,5 +188,33 @@ public final class ScriptRunner: @unchecked Sendable {
           }
         })(globalThis["\(name)"]);
         """)
+    }
+}
+
+/// Lock-protected one-shot result holder used by `ScriptRunner.invoke`
+/// to ferry the JS evaluation outcome from the dedicated queue back to
+/// the caller. The semaphore guarantees happens-before, but Swift 6
+/// concurrency checking requires explicit thread safety on the type.
+private final class InvocationResultBox: @unchecked Sendable {
+    struct Snapshot {
+        let json: String?
+        let error: String?
+    }
+
+    private let lock = NSLock()
+    private var json: String?
+    private var error: String?
+
+    func set(json: String?, error: String?) {
+        lock.lock()
+        self.json = json
+        self.error = error
+        lock.unlock()
+    }
+
+    func get() -> Snapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return Snapshot(json: json, error: error)
     }
 }

--- a/Sources/ChatClientKit/Scripting/ScriptRunner.swift
+++ b/Sources/ChatClientKit/Scripting/ScriptRunner.swift
@@ -113,9 +113,10 @@ public final class ScriptRunner: @unchecked Sendable {
         // between the writer (queue.async closure) and reader (after sem.wait),
         // but the type system needs us to be explicit.
         let box = InvocationResultBox()
+        let sendableBindings = SendableBindings(values: bindings)
 
-        queue.async { [self] in
-            for (key, value) in bindings {
+        queue.async { [self, sendableBindings] in
+            for (key, value) in sendableBindings.values {
                 ctx.setObject(value, forKeyedSubscript: key as NSString)
             }
             let wrapped = """
@@ -189,6 +190,10 @@ public final class ScriptRunner: @unchecked Sendable {
         })(globalThis["\(name)"]);
         """)
     }
+}
+
+private struct SendableBindings: @unchecked Sendable {
+    let values: [String: Any]
 }
 
 /// Lock-protected one-shot result holder used by `ScriptRunner.invoke`

--- a/Sources/ChatClientKit/Scripting/ScriptRunner.swift
+++ b/Sources/ChatClientKit/Scripting/ScriptRunner.swift
@@ -1,0 +1,190 @@
+//
+//  ScriptRunner.swift
+//  ChatClientKit
+//
+//  Per-request JavaScriptCore harness.
+//  - Dedicated DispatchQueue (serial) for all JSContext access.
+//  - 5s hard timeout on script execution → fatalError(plan §1.8).
+//  - Large objects (manifest / chatSession) frozen and bound once at
+//    init, so per-chunk invokes carry only chunk-local payloads.
+//  - JS global `context` initialised from a DB string via JSON.parse
+//    with strict type validation; scripts read/write that object freely.
+//
+
+import Foundation
+import JavaScriptCore
+
+/// Errors surfaced by the runner that originate from the JS side
+/// or its bridging.
+public enum ScriptRunnerError: Error, LocalizedError {
+    case jsException(String)
+    case noOutput
+    case encodeFailure(Error)
+    case decodeFailure(Error)
+    case contextUnavailable
+
+    public var errorDescription: String? {
+        switch self {
+        case let .jsException(msg): "JavaScript exception: \(msg)"
+        case .noOutput: "Script returned no `__result` value"
+        case let .encodeFailure(e): "Failed to encode input for JS: \(e)"
+        case let .decodeFailure(e): "Failed to decode JS output: \(e)"
+        case .contextUnavailable: "JSContext could not be created"
+        }
+    }
+}
+
+public final class ScriptRunner: @unchecked Sendable {
+    private let queue: DispatchQueue
+    private let ctx: JSContext
+    private let bridge: ScriptBridge
+
+    /// Wall-clock budget per `invoke` call. Plan §1.8 — exceeded → fatalError.
+    /// 5s in production; tests using mocked executors don't hit this path.
+    private let invokeTimeout: DispatchTimeInterval
+
+    public init(
+        initialContextJSON: String,
+        manifest: ManifestSnapshot,
+        session: ChatSessionSnapshot,
+        bridge: ScriptBridge,
+        invokeTimeout: DispatchTimeInterval = .seconds(5)
+    ) throws {
+        queue = DispatchQueue(
+            label: "cck.script.\(UUID().uuidString)",
+            qos: .userInitiated
+        )
+        guard let ctx = JSContext() else { throw ScriptRunnerError.contextUnavailable }
+        self.ctx = ctx
+        self.bridge = bridge
+        self.invokeTimeout = invokeTimeout
+
+        // toJSObject is throws; do it OUTSIDE queue.sync so init can rethrow.
+        // queue.sync's closure body can't propagate throws to the init.
+        let manifestObject: Any
+        let sessionObject: Any
+        do {
+            manifestObject = try Self.toJSObject(manifest)
+            sessionObject = try Self.toJSObject(session)
+        } catch {
+            throw ScriptRunnerError.encodeFailure(error)
+        }
+
+        let escapedContextJSON = initialContextJSON
+
+        queue.sync { [ctx] in
+            // cck.* bridge
+            ctx.setObject(bridge, forKeyedSubscript: "cck" as NSString)
+
+            // Manifest / chatSession deep-frozen globals.
+            Self.installSafeImmutableGlobal(in: ctx, name: "manifest", object: manifestObject)
+            Self.installSafeImmutableGlobal(in: ctx, name: "chatSession", object: sessionObject)
+
+            // Context bootstrap: never interpolate the DB string into JS
+            // source. Pass via setObject, then JSON.parse + type guard.
+            ctx.setObject(escapedContextJSON, forKeyedSubscript: "__contextJSON" as NSString)
+            ctx.evaluateScript("""
+            var context = (function() {
+              try {
+                if (typeof __contextJSON !== "string" || __contextJSON.length === 0) return {};
+                var v = JSON.parse(__contextJSON);
+                if (typeof v === "object" && v !== null && !Array.isArray(v)) return v;
+                return {};
+              } catch (e) { return {}; }
+            })();
+            delete globalThis.__contextJSON;
+            """)
+        }
+    }
+
+    /// Synchronous-from-JS-perspective invocation.
+    /// `bindings` are chunk-local inputs (headers/body for pre,
+    /// line/parsed for post). Do NOT pass manifest/session here — they
+    /// live as immutable globals.
+    public func invoke<Output: Decodable>(
+        script: String,
+        bindings: [String: Any] = [:],
+        decoding _: Output.Type = Output.self
+    ) throws -> Output {
+        let sem = DispatchSemaphore(value: 0)
+        var jsonResult: String?
+        var jsError: String?
+
+        queue.async { [self] in
+            for (key, value) in bindings {
+                ctx.setObject(value, forKeyedSubscript: key as NSString)
+            }
+            // Wrapper:
+            //   - Provides a local __result the user script assigns to.
+            //   - Returns JSON.stringify(__result). If __result is
+            //     undefined, JSON.stringify yields undefined as well —
+            //     we detect that on the Swift side.
+            let wrapped = """
+            (function() {
+              var __result = undefined;
+              \(script)
+              ;return JSON.stringify(__result);
+            })()
+            """
+            if let value = ctx.evaluateScript(wrapped),
+               !value.isUndefined, !value.isNull
+            {
+                jsonResult = value.toString()
+            }
+            if let exception = ctx.exception {
+                jsError = exception.toString()
+                ctx.exception = nil
+            }
+            sem.signal()
+        }
+
+        if sem.wait(timeout: .now() + invokeTimeout) == .timedOut {
+            // Plan §1.8 — only way to free the queue is to kill the process.
+            // No `onTimeout` closure injection; would only mislead tests.
+            fatalError(
+                "ChatClientKit script exceeded \(invokeTimeout) budget — developer must fix the script. Process is doomed."
+            )
+        }
+
+        if let err = jsError { throw ScriptRunnerError.jsException(err) }
+        guard let json = jsonResult, json != "undefined" else {
+            throw ScriptRunnerError.noOutput
+        }
+        do {
+            return try JSONDecoder().decode(Output.self, from: Data(json.utf8))
+        } catch {
+            throw ScriptRunnerError.decodeFailure(error)
+        }
+    }
+
+    /// Encode a Codable value as a Foundation object graph
+    /// (NSDictionary/NSArray/NSString/NSNumber) suitable for
+    /// `JSContext.setObject(_:forKeyedSubscript:)` bridging.
+    /// Avoids string-interpolating into JS source (injection-safe).
+    private static func toJSObject<T: Encodable>(_ value: T) throws -> Any {
+        let data = try JSONEncoder().encode(value)
+        return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+    }
+
+    /// Install a global as a frozen, non-configurable property.
+    /// Deep-freeze walks the entire object graph so nested arrays/objects
+    /// can't be mutated by scripts.
+    private static func installSafeImmutableGlobal(
+        in ctx: JSContext,
+        name: String,
+        object: Any
+    ) {
+        ctx.setObject(object, forKeyedSubscript: name as NSString)
+        // Wrap in an IIFE that defines the binding name as
+        // non-writable + deep-freeze the value.
+        ctx.evaluateScript("""
+        (function deepFreeze(o) {
+          if (o === null || typeof o !== "object") return;
+          Object.freeze(o);
+          for (var k in o) {
+            if (Object.prototype.hasOwnProperty.call(o, k)) deepFreeze(o[k]);
+          }
+        })(globalThis["\(name)"]);
+        """)
+    }
+}

--- a/Sources/ChatClientKit/Scripting/ScriptRuntime.swift
+++ b/Sources/ChatClientKit/Scripting/ScriptRuntime.swift
@@ -1,0 +1,44 @@
+//
+//  ScriptRuntime.swift
+//  ChatClientKit
+//
+//  Bundles a ScriptRunner with its Pre/Post processors for a single
+//  streamingChat request lifetime. One runtime per request.
+//
+
+import Foundation
+
+/// Built once at the start of a streamingChat call. Discarded when the
+/// stream ends. Never reused across requests.
+struct ScriptRuntime {
+    let runner: ScriptRunner
+    let preProcessor: PreProcessor?
+    let postProcessor: PostProcessor?
+
+    /// Build from a request body + a (possibly partial) scripting handle.
+    /// Errors only if Codable serialization of body/manifest fails, which
+    /// is logged and surfaced to the caller.
+    static func make(
+        body: ChatRequestBody,
+        handle: ChatScriptingHandle
+    ) throws -> ScriptRuntime {
+        let session = try ChatSessionSnapshot.make(from: body)
+        let initial = handle.readContext()
+
+        let bridge = ScriptBridge(onWriteContext: handle.writeContext)
+        let runner = try ScriptRunner(
+            initialContextJSON: initial,
+            manifest: handle.manifest,
+            session: session,
+            bridge: bridge
+        )
+
+        let pre = handle.config.preProcess.map {
+            PreProcessor(runner: runner, stage: $0)
+        }
+        let post = handle.config.postProcess.map {
+            PostProcessor(runner: runner, stage: $0)
+        }
+        return ScriptRuntime(runner: runner, preProcessor: pre, postProcessor: post)
+    }
+}

--- a/Sources/ChatClientKit/Scripting/ScriptingStreamError.swift
+++ b/Sources/ChatClientKit/Scripting/ScriptingStreamError.swift
@@ -1,0 +1,24 @@
+//
+//  ScriptingStreamError.swift
+//  ChatClientKit
+//
+//  Errors surfaced by stream processors when the post_process JS
+//  hook fails repeatedly. Collected into the client's `errorCollector`
+//  so consumers see a clear failure even though `AsyncStream` itself
+//  cannot throw.
+//
+
+import Foundation
+
+public enum ScriptingStreamError: Error, LocalizedError {
+    /// post_process script threw / failed to decode `count` times in a row;
+    /// stream was terminated to avoid presenting partial output as success.
+    case consecutivePostProcessFailures(count: Int, last: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .consecutivePostProcessFailures(count, last):
+            "post_process script failed \(count) consecutive times; last error: \(last.localizedDescription)"
+        }
+    }
+}

--- a/Tests/ChatClientKitTests/Scripting/ScriptingStreamProcessorTests.swift
+++ b/Tests/ChatClientKitTests/Scripting/ScriptingStreamProcessorTests.swift
@@ -1,0 +1,315 @@
+//
+//  ScriptingStreamProcessorTests.swift
+//  ChatClientKitTests
+//
+//  Focused unit tests covering the four scripting review findings:
+//  1. Recoverable post_process failures (1-2 consecutive) must not produce
+//     a terminal error in errorCollector.
+//  2. Three consecutive post_process failures produce a terminal error.
+//  3. Completions scripting mode: provider error JSON reaches errorCollector.
+//  4. Responses scripting: chatSession reflects the resolved model/stream.
+//
+
+@testable import ChatClientKit
+import Foundation
+import ServerEvent
+import Testing
+
+struct ScriptingStreamProcessorTests {
+    // MARK: - Helpers
+
+    private func makePostProcessHandle(script: String) -> ChatScriptingHandle {
+        ChatScriptingHandle(
+            conversationId: UUID().uuidString,
+            config: ChatClientKitScriptConfig(
+                preProcess: nil,
+                postProcess: .init(inherit: false, script: script)
+            ),
+            manifest: ManifestSnapshot(payload: .object([:])),
+            readContext: { "{}" },
+            writeContext: { _ in }
+        )
+    }
+
+    private func makeCompletionsClient(
+        rawLines: [String]
+    ) -> (client: RemoteCompletionsChatClient, factory: ScriptingMockEventFactory) {
+        let factory = ScriptingMockEventFactory(rawLines: rawLines)
+        let dependencies = RemoteClientDependencies(
+            session: ScriptingMockURLSession(),
+            eventSourceFactory: factory,
+            responseDecoderFactory: { JSONDecoderWrapper() },
+            chunkDecoderFactory: { JSONDecoderWrapper() },
+            errorExtractor: RemoteChatErrorExtractor(),
+            reasoningParser: CompletionReasoningDecoder(),
+            requestSanitizer: RequestSanitizer()
+        )
+        let client = RemoteCompletionsChatClient(
+            model: "test-model",
+            baseURL: "https://example.com",
+            path: "/v1/chat/completions",
+            apiKey: "sk-test",
+            dependencies: dependencies
+        )
+        return (client, factory)
+    }
+
+    private func makeResponsesClient(
+        rawLines: [String]
+    ) -> (client: RemoteResponsesChatClient, factory: ScriptingMockEventFactory) {
+        let factory = ScriptingMockEventFactory(rawLines: rawLines)
+        let dependencies = RemoteClientDependencies(
+            session: ScriptingMockURLSession(),
+            eventSourceFactory: factory,
+            responseDecoderFactory: { JSONDecoderWrapper() },
+            chunkDecoderFactory: { JSONDecoderWrapper() },
+            errorExtractor: RemoteResponsesErrorExtractor(),
+            reasoningParser: CompletionReasoningDecoder(),
+            requestSanitizer: RequestSanitizer()
+        )
+        let client = RemoteResponsesChatClient(
+            model: "test-model",
+            baseURL: "https://example.com",
+            path: "/v1/responses",
+            apiKey: "sk-test",
+            dependencies: dependencies
+        )
+        return (client, factory)
+    }
+
+    // MARK: - Test 1: Recoverable post_process failures - no terminal error
+
+    @Test
+    func `completions post_process fails first two chunks then recovers - no error collected`() async throws {
+        // Script fails for first 2 invocations, succeeds from the 3rd onward.
+        // Uses `context` which persists across invoke calls in the same JSContext.
+        let script = """
+        if (!context.count) context.count = 0;
+        context.count++;
+        if (context.count <= 2) { throw new Error("transient failure " + context.count); }
+        __result = { content: "ok", reasoning: null, tool_calls: null };
+        """
+        let handle = makePostProcessHandle(script: script)
+
+        let chunk = #"{"choices":[{"delta":{"content":"token"}}]}"#
+        let (client, _) = makeCompletionsClient(rawLines: [chunk, chunk, chunk])
+
+        let stream = try await client.streamingChat(
+            body: ChatRequestBody(messages: [.user(content: .text("hi"))]),
+            scripting: handle
+        )
+        for try await _ in stream {}
+
+        #expect(client.collectedErrors == nil,
+                "Recoverable failures must not populate errorCollector")
+    }
+
+    @Test
+    func `responses post_process fails first two chunks then recovers - no error collected`() async throws {
+        let script = """
+        if (!context.count) context.count = 0;
+        context.count++;
+        if (context.count <= 2) { throw new Error("transient failure " + context.count); }
+        __result = { content: "ok", reasoning: null, tool_calls: null };
+        """
+        let handle = makePostProcessHandle(script: script)
+
+        let chunk = #"{"type":"response.output_text.delta","item_id":"m1","delta":"Hi"}"#
+        let (client, _) = makeResponsesClient(rawLines: [chunk, chunk, chunk])
+
+        let stream = try await client.streamingChat(
+            body: ChatRequestBody(messages: [.user(content: .text("hi"))]),
+            scripting: handle
+        )
+        for try await _ in stream {}
+
+        #expect(client.collectedErrors == nil,
+                "Recoverable failures must not populate errorCollector")
+    }
+
+    // MARK: - Test 2: Three consecutive failures -> terminal error
+
+    @Test
+    func `completions post_process three consecutive failures produce terminal error`() async throws {
+        let script = """
+        throw new Error("always fails");
+        """
+        let handle = makePostProcessHandle(script: script)
+
+        let chunk = #"{"choices":[{"delta":{"content":"token"}}]}"#
+        let (client, _) = makeCompletionsClient(rawLines: [chunk, chunk, chunk, chunk])
+
+        let stream = try await client.streamingChat(
+            body: ChatRequestBody(messages: [.user(content: .text("hi"))]),
+            scripting: handle
+        )
+        for try await _ in stream {}
+
+        let errors = client.collectedErrors
+        #expect(errors != nil, "Terminal error must be collected after 3 consecutive failures")
+        // ScriptingStreamError.consecutivePostProcessFailures description contains the count
+        let desc = errors ?? ""
+        #expect(
+            desc.contains("3") || desc.contains("consecutive") || desc.contains("post_process"),
+            "Error description should identify the terminal post_process failure; got: \(desc)"
+        )
+    }
+
+    @Test
+    func `responses post_process three consecutive failures produce terminal error`() async throws {
+        let script = """
+        throw new Error("always fails");
+        """
+        let handle = makePostProcessHandle(script: script)
+
+        let chunk = #"{"type":"response.output_text.delta","item_id":"m1","delta":"Hi"}"#
+        let (client, _) = makeResponsesClient(rawLines: [chunk, chunk, chunk, chunk])
+
+        let stream = try await client.streamingChat(
+            body: ChatRequestBody(messages: [.user(content: .text("hi"))]),
+            scripting: handle
+        )
+        for try await _ in stream {}
+
+        let errors = client.collectedErrors
+        #expect(errors != nil, "Terminal error must be collected after 3 consecutive failures")
+        let desc = errors ?? ""
+        #expect(
+            desc.contains("3") || desc.contains("consecutive") || desc.contains("post_process"),
+            "Error description should identify the terminal post_process failure; got: \(desc)"
+        )
+    }
+
+    // MARK: - Test 3: Completions scripting - provider error JSON reaches errorCollector
+
+    @Test
+    func `completions scripting mode surfaces provider error JSON into errorCollector`() async throws {
+        // Script always succeeds; the provider error in the SSE data must still
+        // reach errorCollector via errorExtractor.extractError inside Path A.
+        let script = """
+        __result = { content: null, reasoning: null, tool_calls: null };
+        """
+        let handle = makePostProcessHandle(script: script)
+
+        // Standard OpenAI-style error payload
+        let providerError = #"{"error":{"message":"Rate limit exceeded","type":"rate_limit_error","code":429}}"#
+        let (client, _) = makeCompletionsClient(rawLines: [providerError])
+
+        let stream = try await client.streamingChat(
+            body: ChatRequestBody(messages: [.user(content: .text("hi"))]),
+            scripting: handle
+        )
+        for try await _ in stream {}
+
+        let errors = client.collectedErrors
+        #expect(errors != nil,
+                "Provider error JSON must reach errorCollector even when scripting is active")
+        #expect(errors?.contains("Rate limit") == true,
+                "errorCollector should include the provider error message; got: \(errors ?? "nil")")
+    }
+
+    // MARK: - Test 4: Responses scripting chatSession reflects resolved model/stream
+
+    @Test
+    func `responses scripting chatSession contains resolved model and stream`() async throws {
+        // Script reads chatSession.model and chatSession.stream and returns them
+        // as content so we can verify the values from outside.
+        let script = """
+        var m = (chatSession && chatSession.model) ? chatSession.model : "MISSING_MODEL";
+        var s = (chatSession && chatSession.stream !== undefined) ? String(chatSession.stream) : "MISSING_STREAM";
+        __result = { content: m + "|" + s, reasoning: null, tool_calls: null };
+        """
+        let handle = ChatScriptingHandle(
+            conversationId: UUID().uuidString,
+            config: ChatClientKitScriptConfig(
+                preProcess: nil,
+                postProcess: .init(inherit: false, script: script)
+            ),
+            manifest: ManifestSnapshot(payload: .object([:])),
+            readContext: { "{}" },
+            writeContext: { _ in }
+        )
+
+        // Send one Responses-format chunk so the script fires once.
+        let chunk = #"{"type":"response.output_text.delta","item_id":"m1","delta":"Hi"}"#
+        let factory = ScriptingMockEventFactory(rawLines: [chunk])
+        let dependencies = RemoteClientDependencies(
+            session: ScriptingMockURLSession(),
+            eventSourceFactory: factory,
+            responseDecoderFactory: { JSONDecoderWrapper() },
+            chunkDecoderFactory: { JSONDecoderWrapper() },
+            errorExtractor: RemoteResponsesErrorExtractor(),
+            reasoningParser: CompletionReasoningDecoder(),
+            requestSanitizer: RequestSanitizer()
+        )
+        // model is set to "resolved-model" on the client; the body passed to
+        // streamingChat has model=nil so we verify the resolved value propagates.
+        let client = RemoteResponsesChatClient(
+            model: "resolved-model",
+            baseURL: "https://example.com",
+            path: "/v1/responses",
+            apiKey: "sk-test",
+            dependencies: dependencies
+        )
+
+        let stream = try await client.streamingChat(
+            body: ChatRequestBody(messages: [.user(content: .text("hi"))]),
+            scripting: handle
+        )
+
+        var texts: [String] = []
+        for try await chunk in stream {
+            if let t = chunk.textValue { texts.append(t) }
+        }
+        let received = texts.joined()
+
+        #expect(received.contains("resolved-model"),
+                "chatSession.model must be the resolved model name; got: \(received)")
+        #expect(received.contains("true"),
+                "chatSession.stream must be true (resolved stream=true); got: \(received)")
+    }
+}
+
+// MARK: - Test doubles (scoped to this file)
+
+private final class ScriptingMockURLSession: URLSessioning, @unchecked Sendable {
+    func data(for _: URLRequest) async throws -> (Data, URLResponse) {
+        throw URLError(.notConnectedToInternet)
+    }
+}
+
+private final class ScriptingMockEventFactory: EventSourceProducing, @unchecked Sendable {
+    private let recordedEvents: [EventSource.EventType]
+
+    init(rawLines: [String]) {
+        var evs: [EventSource.EventType] = [.open]
+        for line in rawLines {
+            evs.append(.event(ScriptingTestEvent(data: line)))
+        }
+        evs.append(.closed)
+        recordedEvents = evs
+    }
+
+    func makeDataTask(for _: URLRequest) -> EventStreamTask {
+        ScriptingMockEventStreamTask(recordedEvents: recordedEvents)
+    }
+}
+
+private struct ScriptingMockEventStreamTask: EventStreamTask {
+    let recordedEvents: [EventSource.EventType]
+
+    func events() -> AsyncStream<EventSource.EventType> {
+        AsyncStream { cont in
+            for e in recordedEvents { cont.yield(e) }
+            cont.finish()
+        }
+    }
+}
+
+private struct ScriptingTestEvent: EVEvent {
+    var id: String?
+    var event: String?
+    var data: String?
+    var other: [String: String]?
+    var time: String?
+}


### PR DESCRIPTION
## Summary

Adds opt-in JavaScript hooks to `RemoteCompletionsChatClient` and `RemoteResponsesChatClient` so app-side scripts can rewrite the outbound URLRequest (`pre_process`) and the streaming SSE chunks (`post_process`) without an app release. Local-inference clients (MLX, AppleIntelligence) are unaffected.

- New `Scripting/` module: `ScriptRunner` (per-request `JSContext` on a dedicated queue, 5s hard timeout → fatalError), `ScriptBridge` (`cck.saveContext` with 5s synchronous-write watchdog, plus log / base64 / sha256 / hmacSHA256), strong-typed I/O (`PreProcessOutput` / `PostProcessOutput` / `ChatSessionSnapshot` / `ManifestSnapshot`), `ChatClientKitScriptConfig` (plist-decoded), `ChatScriptingHandle` (connector struct injected by app adapter), `Pre/PostProcessor`, `ScriptRuntime` aggregator, `ScriptingStreamError`.
- `ChatService` protocol gains `streamingChat(body:scripting:)` with a default impl that forwards to the no-scripting variant — MLX / AppleIntelligence inherit it unchanged.
- `RemoteCompletions` / `RemoteResponses` clients override and thread the runtime through `RequestBuilder` (pre) and `StreamProcessor` (post; 3-strike consecutive-failure → terminal `errorCollector` + finish).

Plan + design rationale in `Documentation/ChatClientKit-Scripting-Plan.md` of the FlowDown repo.

## Constraints baked in
- Scripts non-editable in-app (Apple Review safe).
- Script timeout = `fatalError` (no degradation).
- `saveContext` synchronous; cross-queue write with 5s watchdog → `fatalError` on lock inversion.
- Manifest is an opaque `payload: AnyCodingValue`; ChatClientKit does not import Storage. App-side adapter constructs the whitelist.

## Test plan
- [ ] FlowDownUnitTests: 23/23 pass locally
- [ ] CI: GitHub Actions tests workflow green
- [ ] Manual: end-to-end smoke with a sample `chat_client_kit_scripts` plist in `CloudModel.ext_data`

🤖 Generated with [Claude Code](https://claude.com/claude-code)